### PR TITLE
Pointer input device extension

### DIFF
--- a/appium-dotnet-driver/Appium/AppiumCommand.cs
+++ b/appium-dotnet-driver/Appium/AppiumCommand.cs
@@ -104,6 +104,14 @@ namespace OpenQA.Selenium.Appium
 
             #endregion Touch Commands
 
+            // Enable W3C Actions on AppiumWebDriver
+            #region W3C Actions
+
+            new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.Actions,
+                "/session/{sessionId}/actions"),
+
+            #endregion W3C Actions
+
             #region JSON Wire Protocol Commands
 
             new AppiumCommand(CommandInfo.GetCommand, AppiumDriverCommand.GetOrientation,

--- a/appium-dotnet-driver/Appium/AppiumDriver.cs
+++ b/appium-dotnet-driver/Appium/AppiumDriver.cs
@@ -17,6 +17,7 @@ using Newtonsoft.Json;
 using OpenQA.Selenium.Appium.Enums;
 using OpenQA.Selenium.Appium.Interfaces;
 using OpenQA.Selenium.Appium.Service;
+using OpenQA.Selenium.Interactions;
 using OpenQA.Selenium.Remote;
 using System;
 using System.Collections;
@@ -384,6 +385,30 @@ namespace OpenQA.Selenium.Appium
         }
 
         #endregion Multi Actions
+
+        #region W3C Actions
+
+        // Replace or hide the original RemoteWebElement.PerformActions base method so that it does not require
+        // AppiumDriver to be fully compliant with W3CWireProtocol specification to execute W3C actions command.
+        public new void PerformActions(IList<ActionSequence> actionSequenceList)
+        {
+            if (actionSequenceList == null)
+            {
+                throw new ArgumentNullException("actionSequenceList", "List of action sequences must not be null");
+            }
+
+            List<object> objectList = new List<object>();
+            foreach (ActionSequence sequence in actionSequenceList)
+            {
+                objectList.Add(sequence.ToDictionary());
+            }
+
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+            parameters["actions"] = objectList;
+            this.Execute(DriverCommand.Actions, parameters);
+        }
+
+        #endregion W3C Actions
 
         #region Device Time
 

--- a/appium-dotnet-driver/Appium/AppiumDriverCommand.cs
+++ b/appium-dotnet-driver/Appium/AppiumDriverCommand.cs
@@ -46,7 +46,7 @@ namespace OpenQA.Selenium.Appium
         public const string ToggleAirplaneMode = "toggleAirplaneMode";
 
         /// <summary>
-        /// Press key code 
+        /// Press key code
         /// </summary>
         public const string PressKeyCode = "pressKeyCode";
 
@@ -175,6 +175,15 @@ namespace OpenQA.Selenium.Appium
         public const string PerformMultiAction = "performMultiTouch";
 
         #endregion MultiTouchActions
+
+        #region W3C Actions
+
+        /// <summary>
+        /// Perform multi purpose W3C actions
+        /// </summary>
+        public const string Actions = "actions";
+
+        #endregion W3C Actions
 
         #region Context Commands
 

--- a/appium-dotnet-driver/Appium/Interactions/InteractionInfo.cs
+++ b/appium-dotnet-driver/Appium/Interactions/InteractionInfo.cs
@@ -1,0 +1,173 @@
+﻿//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//See the NOTICE file distributed with this work for additional
+//information regarding copyright ownership.
+//You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+using System;
+using System.Collections.Generic;
+
+namespace OpenQA.Selenium.Appium.Interactions
+{
+    /// <summary>
+    /// Provides a method by which optional attributes can be added to an Interactions.
+    /// </summary>
+    public interface IInteractionInfo
+    {
+        /// <summary>
+        /// Returns optional values that are set to extend the default interaction values.
+        /// </summary>
+        /// <returns>A <see cref="Dictionary{TKey, TValue}"/> representing the values that are set.</returns>
+        Dictionary<string, object> ToDictionary();
+    }
+
+    /// <summary>
+    /// Represents a collection of optional attributes for pen pointer interaction.
+    /// </summary>
+    public class PenInfo : IInteractionInfo
+    {
+        /// <summary>
+        /// Specifies pen buttons that can be pressed on pen interactions.
+        /// </summary>
+        [Flags]
+        public enum PenButton
+        {
+            Uninitialized = -1,
+
+            /// <summary>
+            /// No button is pressed
+            /// </summary>
+            None = 0,
+
+            /// <summary>
+            /// The barrel/right click button
+            /// </summary>
+            Barrel = 2,
+
+            /// <summary>
+            /// The eraser/top button
+            /// </summary>
+            Eraser = 32
+        }
+
+        /// <summary>
+        /// Gets or sets which pen button(s) that is/are pressed. E.g. PenButton.Barrel | PenButton.Eraser
+        /// </summary>
+        public PenButton PenButtons = PenButton.Uninitialized;
+
+        /// <summary>
+        /// Gets or sets the force exerted by the pen device
+        /// </summary>
+        public double? Pressure { get; set; }
+
+        /// <summary>
+        /// Gets or sets the clockwise rotation or twist of the pen device
+        /// </summary>
+        public double? Rotation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the angle of tilt of the pen device along the x-axis
+        /// </summary>
+        public int? TiltX { get; set; }
+
+        /// <summary>
+        /// Gets or sets the angle of tilt of the pen device along the y-axis
+        /// </summary>
+        public int? TiltY { get; set; }
+
+        /// <summary>
+        /// Returns optional values that are set to extend the default pen pointer interaction values.
+        /// </summary>
+        /// <returns>A <see cref="Dictionary{TKey, TValue}"/> representing the values that are set.</returns>
+        public Dictionary<string, object> ToDictionary()
+        {
+            Dictionary<string, object> toReturn = new Dictionary<string, object>();
+
+            if (PenButtons != PenButton.Uninitialized)
+            {
+                toReturn["buttons"] = PenButtons;
+            }
+            if (Pressure.HasValue)
+            {
+                toReturn["pressure"] = Pressure;
+            }
+            if (Rotation.HasValue)
+            {
+                toReturn["rotation"] = Rotation;
+            }
+            if (TiltX.HasValue)
+            {
+                toReturn["tiltX "] = TiltX;
+            }
+            if (TiltY.HasValue)
+            {
+                toReturn["tiltY "] = TiltY;
+            }
+
+            return toReturn;
+        }
+    }
+
+    /// <summary>
+    /// Represents a collection of optional attributes for touch pointer interaction.
+    /// </summary>
+    public class TouchInfo : IInteractionInfo
+    {
+        /// <summary>
+        /// Gets or sets the force exerted by the touch contact on the surface
+        /// </summary>
+        public double? Pressure { get; set; }
+
+        /// <summary>
+        /// Gets or sets the counter-clockwise angle of rotation around the major axis of the pointer
+        /// device (the z-axis, perpendicular to the surface of the digitizer).
+        /// </summary>
+        public int? Orientation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the width of the bounding box centered in the touch contact area
+        /// </summary>
+        public int? Width { get; set; }
+
+        /// <summary>
+        /// Gets or sets the height of the bounding box centered in the touch contact area
+        /// </summary>
+        public int? Height { get; set; }
+
+        /// <summary>
+        /// Returns optional values that are set to extend the default touch pointer interaction values.
+        /// </summary>
+        /// <returns>A <see cref="Dictionary{TKey, TValue}"/> representing the values that are set.</returns>
+        public Dictionary<string, object> ToDictionary()
+        {
+            Dictionary<string, object> toReturn = new Dictionary<string, object>();
+
+            if (Pressure.HasValue)
+            {
+                toReturn["pressure"] = Pressure;
+            }
+            if (Orientation.HasValue)
+            {
+                toReturn["orientation"] = Orientation;
+            }
+            if (Width.HasValue)
+            {
+                toReturn["width "] = Width;
+            }
+            if (Height.HasValue)
+            {
+                toReturn["height "] = Height;
+            }
+
+            return toReturn;
+        }
+    }
+}

--- a/appium-dotnet-driver/Appium/Interactions/InteractionInfo.cs
+++ b/appium-dotnet-driver/Appium/Interactions/InteractionInfo.cs
@@ -12,7 +12,6 @@
 //See the License for the specific language governing permissions and
 //limitations under the License.
 
-using System;
 using System.Collections.Generic;
 
 namespace OpenQA.Selenium.Appium.Interactions
@@ -35,51 +34,22 @@ namespace OpenQA.Selenium.Appium.Interactions
     public class PenInfo : IInteractionInfo
     {
         /// <summary>
-        /// Specifies pen buttons that can be pressed on pen interactions.
+        /// The normalized pressure of the pointer input in the range of [0,1]
         /// </summary>
-        [Flags]
-        public enum PenButton
-        {
-            Uninitialized = -1,
-
-            /// <summary>
-            /// No button is pressed
-            /// </summary>
-            None = 0,
-
-            /// <summary>
-            /// The barrel/right click button
-            /// </summary>
-            Barrel = 2,
-
-            /// <summary>
-            /// The eraser/top button
-            /// </summary>
-            Eraser = 32
-        }
+        public float? Pressure { get; set; }
 
         /// <summary>
-        /// Gets or sets which pen button(s) that is/are pressed. E.g. PenButton.Barrel | PenButton.Eraser
+        /// The clockwise rotation (in degrees, in the range of [0,359]) of a transducer (e.g. pen stylus) around its own major axis
         /// </summary>
-        public PenButton PenButtons = PenButton.Uninitialized;
+        public int? Twist { get; set; }
 
         /// <summary>
-        /// Gets or sets the force exerted by the pen device
-        /// </summary>
-        public double? Pressure { get; set; }
-
-        /// <summary>
-        /// Gets or sets the clockwise rotation or twist of the pen device
-        /// </summary>
-        public double? Rotation { get; set; }
-
-        /// <summary>
-        /// Gets or sets the angle of tilt of the pen device along the x-axis
+        /// The plane angle (in degrees, in the range of [-90,90]) between the Y-Z plane and the plane containing both the transducer (e.g. pen stylus) axis and the Y axis
         /// </summary>
         public int? TiltX { get; set; }
 
         /// <summary>
-        /// Gets or sets the angle of tilt of the pen device along the y-axis
+        /// The plane angle (in degrees, in the range of [-90,90]) between the X-Z plane and the plane containing both the transducer (e.g. pen stylus) axis and the X axis
         /// </summary>
         public int? TiltY { get; set; }
 
@@ -91,25 +61,21 @@ namespace OpenQA.Selenium.Appium.Interactions
         {
             Dictionary<string, object> toReturn = new Dictionary<string, object>();
 
-            if (PenButtons != PenButton.Uninitialized)
-            {
-                toReturn["buttons"] = PenButtons;
-            }
             if (Pressure.HasValue)
             {
                 toReturn["pressure"] = Pressure;
             }
-            if (Rotation.HasValue)
+            if (Twist.HasValue)
             {
-                toReturn["rotation"] = Rotation;
+                toReturn["twist"] = Twist;
             }
             if (TiltX.HasValue)
             {
-                toReturn["tiltX "] = TiltX;
+                toReturn["tiltX"] = TiltX;
             }
             if (TiltY.HasValue)
             {
-                toReturn["tiltY "] = TiltY;
+                toReturn["tiltY"] = TiltY;
             }
 
             return toReturn;
@@ -122,25 +88,24 @@ namespace OpenQA.Selenium.Appium.Interactions
     public class TouchInfo : IInteractionInfo
     {
         /// <summary>
-        /// Gets or sets the force exerted by the touch contact on the surface
+        /// The normalized pressure of the pointer input in the range of [0,1]
         /// </summary>
-        public double? Pressure { get; set; }
+        public float? Pressure { get; set; }
 
         /// <summary>
-        /// Gets or sets the counter-clockwise angle of rotation around the major axis of the pointer
-        /// device (the z-axis, perpendicular to the surface of the digitizer).
+        /// The clockwise rotation (in degrees, in the range of [0,359]) of a transducer (e.g. pen stylus) around its own major axis
         /// </summary>
-        public int? Orientation { get; set; }
+        public int? Twist { get; set; }
 
         /// <summary>
-        /// Gets or sets the width of the bounding box centered in the touch contact area
+        /// The width (magnitude on the X axis), in pixels of the contact geometry of the pointer
         /// </summary>
-        public int? Width { get; set; }
+        public double? Width { get; set; }
 
         /// <summary>
-        /// Gets or sets the height of the bounding box centered in the touch contact area
+        /// The height (magnitude on the Y axis), in pixels of the contact geometry of the pointer
         /// </summary>
-        public int? Height { get; set; }
+        public double? Height { get; set; }
 
         /// <summary>
         /// Returns optional values that are set to extend the default touch pointer interaction values.
@@ -154,17 +119,17 @@ namespace OpenQA.Selenium.Appium.Interactions
             {
                 toReturn["pressure"] = Pressure;
             }
-            if (Orientation.HasValue)
+            if (Twist.HasValue)
             {
-                toReturn["orientation"] = Orientation;
+                toReturn["twist"] = Twist;
             }
             if (Width.HasValue)
             {
-                toReturn["width "] = Width;
+                toReturn["width"] = Width;
             }
             if (Height.HasValue)
             {
-                toReturn["height "] = Height;
+                toReturn["height"] = Height;
             }
 
             return toReturn;

--- a/appium-dotnet-driver/Appium/Interactions/PointerInputDevice.cs
+++ b/appium-dotnet-driver/Appium/Interactions/PointerInputDevice.cs
@@ -1,0 +1,200 @@
+﻿//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//See the NOTICE file distributed with this work for additional
+//information regarding copyright ownership.
+//You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+using OpenQA.Selenium.Interactions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenQA.Selenium.Appium.Interactions
+{
+    /// <summary>
+    /// Specifies the button used during a pointer down or up action.
+    /// </summary>
+    public enum PointerButton
+    {
+        /// <summary>
+        /// No pointer button is specified
+        /// </summary>
+        None = -1,
+
+        /// <summary>
+        /// Mouse left button
+        /// </summary>
+        LeftMouse = 0,
+
+        /// <summary>
+        /// Default touch contact
+        /// </summary>
+        TouchContact = 0,
+
+        /// <summary>
+        /// The pen tip
+        /// </summary>
+        PenFrontTip = 0,
+
+        /// <summary>
+        /// Mouse middle button
+        /// </summary>
+        MiddleMouse = 1,
+
+        /// <summary>
+        /// The pen tail end where the eraser/top button is
+        /// </summary>
+        PenBackTip = 1,
+
+        /// <summary>
+        /// Mouse right button
+        /// </summary>
+        RightMouse = 2
+    }
+
+    /// <summary>
+    /// Represents a pointer input device such as pen, touch, and mouse. This class extends
+    /// OpenQA.Selenium.Interactions.PointerUInputDevice to add optional interaction values
+    /// such as pressure, rotation, tilt angle, etc.
+    /// </summary>
+    public class PointerInputDevice : Selenium.Interactions.PointerInputDevice
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PointerInputDevice"/> class.
+        /// </summary>
+        /// <param name="pointerKind">The kind of pointer represented by this input device.</param>
+        public PointerInputDevice(PointerKind pointerKind)
+            : base(pointerKind)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PointerInputDevice"/> class.
+        /// </summary>
+        /// <param name="pointerKind">The kind of pointer represented by this input device.</param>
+        /// <param name="deviceName">The unique name for this input device.</param>
+        public PointerInputDevice(PointerKind pointerKind, string deviceName)
+            : base(pointerKind, deviceName)
+        {
+        }
+
+        /// <summary>
+        /// Creates a pointer down action.
+        /// </summary>
+        /// <param name="button">The button of the pointer that should be pressed.</param>
+        /// <returns>The action representing the pointer down gesture.</returns>
+        public Interaction CreatePointerDown(PointerButton button)
+        {
+            return CreatePointerDown((MouseButton)button);
+        }
+
+        /// <summary>
+        /// Creates a pointer up action.
+        /// </summary>
+        /// <param name="button">The button of the pointer that should be released.</param>
+        /// <returns>The action representing the pointer up gesture.</returns>
+        public Interaction CreatePointerUp(PointerButton button)
+        {
+
+            return CreatePointerUp((MouseButton)button);
+        }
+
+        /// <summary>
+        /// Creates a pointer down action.
+        /// </summary>
+        /// <param name="button">The button of the pointer that should be pressed.</param>
+        /// <param name="pointerExtraAttributes">Additional pointer attributes.</param>
+        /// <returns>The action representing the pointer down gesture.</returns>
+        public Interaction CreatePointerDown(PointerButton button, IInteractionInfo pointerExtraAttributes)
+        {
+            return new ExtendedPointerInteraction(CreatePointerDown((MouseButton)button), pointerExtraAttributes);
+        }
+
+        /// <summary>
+        /// Creates a pointer up action.
+        /// </summary>
+        /// <param name="button">The button of the pointer that should be released.</param>
+        /// <param name="pointerExtraAttributes">Additional pointer attributes.</param>
+        /// <returns>The action representing the pointer up gesture.</returns>
+        public Interaction CreatePointerUp(PointerButton button, IInteractionInfo pointerExtraAttributes)
+        {
+            return new ExtendedPointerInteraction(CreatePointerUp((MouseButton)button), pointerExtraAttributes);
+        }
+
+        /// <summary>
+        /// Creates a pointer move action to a specific element.
+        /// </summary>
+        /// <param name="target">The <see cref="IWebElement"/> used as the target for the move.</param>
+        /// <param name="xOffset">The horizontal offset from the origin of the move.</param>
+        /// <param name="yOffset">The vertical offset from the origin of the move.</param>
+        /// <param name="duration">The length of time the move gesture takes to complete.</param>
+        /// <param name="pointerExtraAttributes">Additional pointer attributes.</param>
+        /// <returns>The action representing the pointer move gesture.</returns>
+        public Interaction CreatePointerMove(IWebElement target, int xOffset, int yOffset, TimeSpan duration, IInteractionInfo pointerExtraAttributes)
+        {
+            return new ExtendedPointerInteraction(CreatePointerMove(target, xOffset, yOffset, duration), pointerExtraAttributes);
+        }
+
+        /// <summary>
+        /// Creates a pointer move action to an absolute coordinate.
+        /// </summary>
+        /// <param name="origin">The origin of coordinates for the move. Values can be relative to
+        /// the view port origin, or the most recent pointer position.</param>
+        /// <param name="xOffset">The horizontal offset from the origin of the move.</param>
+        /// <param name="yOffset">The vertical offset from the origin of the move.</param>
+        /// <param name="duration">The length of time the move gesture takes to complete.</param>
+        /// <param name="pointerExtraAttributes">Additional pointer attributes.</param>
+        /// <returns>The action representing the pointer move gesture.</returns>
+        /// <exception cref="ArgumentException">Thrown when passing CoordinateOrigin.Element into origin.
+        /// Users should use the other CreatePointerMove overload to move to a specific element.</exception>
+        public Interaction CreatePointerMove(CoordinateOrigin origin, int xOffset, int yOffset, TimeSpan duration, IInteractionInfo pointerExtraAttributes)
+        {
+            return new ExtendedPointerInteraction(CreatePointerMove(origin, xOffset, yOffset, duration), pointerExtraAttributes);
+        }
+
+        // This class appended the original Interaction defined in OpenQA.Selenium.Interaction with additional
+        // extra attributes of the pointer interaction. This can be removed when the standard interaction objects
+        // in OpenQA.Selenium.Interaction namespace are enhanced to support these additional attributes.
+        private class ExtendedPointerInteraction : Interaction
+        {
+            private Interaction wrappedInteraction;
+            private Dictionary<string, object> pointerInputExtraAttributes;
+
+            public ExtendedPointerInteraction(Interaction pointerInteraction, IInteractionInfo pointerAttributes)
+                : base(pointerInteraction.SourceDevice)
+            {
+                if (pointerInteraction == null)
+                {
+                    throw new ArgumentException("Pointer interaction provided is invalid");
+                }
+
+                if (pointerAttributes == null)
+                {
+                    throw new ArgumentException("Pointer attributes provided is invalid");
+                }
+
+                wrappedInteraction = pointerInteraction;
+                pointerInputExtraAttributes = pointerAttributes.ToDictionary();
+            }
+
+            public override Dictionary<string, object> ToDictionary()
+            {
+                // Get the original payload from the wrapped Interaction
+                Dictionary<string, object> toReturn = wrappedInteraction.ToDictionary();
+
+                // Append the original payload with the given pointer input extra attributes
+                pointerInputExtraAttributes.ToList().ForEach(x => toReturn[x.Key] = x.Value);
+
+                return toReturn;
+            }
+        }
+    }
+}

--- a/appium-dotnet-driver/Appium/Interactions/PointerInputDevice.cs
+++ b/appium-dotnet-driver/Appium/Interactions/PointerInputDevice.cs
@@ -25,7 +25,7 @@ namespace OpenQA.Selenium.Appium.Interactions
     public enum PointerButton
     {
         /// <summary>
-        /// No pointer button is specified
+        /// Neither buttons nor touch/pen contact changed since last event
         /// </summary>
         None = -1,
 
@@ -42,7 +42,7 @@ namespace OpenQA.Selenium.Appium.Interactions
         /// <summary>
         /// The pen tip
         /// </summary>
-        PenFrontTip = 0,
+        PenContact = 0,
 
         /// <summary>
         /// Mouse middle button
@@ -50,14 +50,29 @@ namespace OpenQA.Selenium.Appium.Interactions
         MiddleMouse = 1,
 
         /// <summary>
-        /// The pen tail end where the eraser/top button is
-        /// </summary>
-        PenBackTip = 1,
-
-        /// <summary>
         /// Mouse right button
         /// </summary>
-        RightMouse = 2
+        RightMouse = 2,
+
+        /// <summary>
+        /// Pen barrel button
+        /// </summary>
+        PenBarrel = 2,
+
+        /// <summary>
+        /// Mouse X1 (back) button
+        /// </summary>
+        X1Mouse = 3,
+
+        /// <summary>
+        /// Mouse X1 (forward) button
+        /// </summary>
+        X2Mouse = 4,
+
+        /// <summary>
+        /// The pen eraser button
+        /// </summary>
+        PenEraser = 5
     }
 
     /// <summary>

--- a/appium-dotnet-driver/appium-dotnet-driver.csproj
+++ b/appium-dotnet-driver/appium-dotnet-driver.csproj
@@ -71,6 +71,8 @@
     <Compile Include="Appium\Enums\MobileCapabilityType.cs" />
     <Compile Include="Appium\Android\Enums\ConnectionType.cs" />
     <Compile Include="Appium\Enums\MobileSelector.cs" />
+    <Compile Include="Appium\Interactions\InteractionInfo.cs" />
+    <Compile Include="Appium\Interactions\PointerInputDevice.cs" />
     <Compile Include="Appium\Interfaces\IFindsByIosNSPredicate.cs" />
     <Compile Include="Appium\Interfaces\IExecuteMethod.cs" />
     <Compile Include="Appium\Interfaces\IFindsByFluentSelector.cs" />


### PR DESCRIPTION
## Change list

Enable AppiumDriver to perform W3CWebDriver Actions and implement support for additional pointer interaction attributes such as pressure, twist, tilt etc.
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

Sample code for extra pen attributes:

```c#
PointerInputDevice penDevice = new PointerInputDevice(PointerKind.Pen);
ActionSequence sequence = new ActionSequence(penDevice, 0);
PenInfo penExtraAttributes = new PenInfo { TiltX = 45, TiltY = 45, Twist = 45 };

// Draw line AB from point A to B with attributes defined in penExtraAttributes
sequence.AddAction(penDevice.CreatePointerMove(CoordinateOrigin.Pointer, A.X, A.Y, TimeSpan.Zero));
sequence.AddAction(penDevice.CreatePointerDown(PointerButton.PenContact, penExtraAttributes));
sequence.AddAction(penDevice.CreatePointerMove(CoordinateOrigin.Pointer, squareSize.Width, 0, TimeSpan.Zero));
sequence.AddAction(penDevice.CreatePointerUp(PointerButton.PenContact));

// Draw line BC from point B to C and apply maximum (1.0f) pressure as the pen draw between the points
sequence.AddAction(penDevice.CreatePointerDown(PointerButton.PenContact));
sequence.AddAction(penDevice.CreatePointerMove(CoordinateOrigin.Pointer, 0, squareSize.Height, TimeSpan.Zero, new PenInfo { Pressure = 1f }));
sequence.AddAction(penDevice.CreatePointerUp(PointerButton.PenContact));

newStickyNoteSession.PerformActions(new List<ActionSequence> { sequence });
```
